### PR TITLE
Refactor subscriber queues to bounded tokio mpsc channels with batching and separate QoS1 inflight tracking

### DIFF
--- a/bench/src/main.rs
+++ b/bench/src/main.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 use auth::StaticApiKeyValidator;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use clap::Parser;
-use corelib::{Broker, BrokerConfig, QoSLevel};
+use corelib::{BackpressurePolicy, Broker, BrokerConfig, QoSLevel};
 use net::{
     encode_frame, try_decode_frame, AckPayload, AuthPayload, BrokerHandler, Frame, FrameType,
     HelloPayload, NetworkConfig, PollPayload, PublishPayload, Server, SubscribePayload,
@@ -404,6 +404,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         default_qos: cfg.qos,
         message_ttl: Duration::from_secs(60),
         per_subscriber_queue_capacity: 4096,
+        per_subscriber_backpressure: BackpressurePolicy::Drop,
         max_retries: 3,
         retry_base_delay: Duration::from_millis(50),
     };

--- a/blipmqd/src/main.rs
+++ b/blipmqd/src/main.rs
@@ -12,7 +12,7 @@ use tracing_subscriber::{fmt, EnvFilter};
 use auth::StaticApiKeyValidator;
 use bytes::Bytes;
 use config::{Config, ConfigError};
-use corelib::{Broker, BrokerConfig, QoSLevel};
+use corelib::{BackpressurePolicy, Broker, BrokerConfig, QoSLevel};
 use metrics::run_metrics_server;
 use net::{
     AckPayload, BrokerHandler, Frame, FrameResponse, FrameType, MessageHandler, NetworkConfig,
@@ -176,6 +176,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     default_qos: QoSLevel::AtLeastOnce,
                     message_ttl: std::time::Duration::from_secs(60),
                     per_subscriber_queue_capacity: 1024,
+                    per_subscriber_backpressure: BackpressurePolicy::Drop,
                     max_retries: config.max_retries,
                     retry_base_delay: std::time::Duration::from_millis(config.retry_backoff_ms),
                 },

--- a/tests/chaos_recovery.rs
+++ b/tests/chaos_recovery.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use chaos::simulate_crash;
-use corelib::{Broker, BrokerConfig, ClientId, QoSLevel, TopicName};
+use corelib::{BackpressurePolicy, Broker, BrokerConfig, ClientId, QoSLevel, TopicName};
 use wal::WriteAheadLog;
 use bytes::Bytes;
 
@@ -29,6 +29,7 @@ async fn chaos_crash_recovery_qos1() {
         default_qos: QoSLevel::AtLeastOnce,
         message_ttl: Duration::from_secs(60),
         per_subscriber_queue_capacity: 1024,
+        per_subscriber_backpressure: BackpressurePolicy::Drop,
         max_retries: 3,
         retry_base_delay: Duration::from_millis(50),
     };
@@ -130,5 +131,4 @@ async fn chaos_crash_recovery_qos1() {
         );
     }
 }
-
 

--- a/tests/daemon_integration.rs
+++ b/tests/daemon_integration.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use auth::StaticApiKeyValidator;
-use corelib::{Broker, BrokerConfig, QoSLevel, TopicName};
+use corelib::{BackpressurePolicy, Broker, BrokerConfig, QoSLevel, TopicName};
 use net::{
     AckPayload, AuthPayload, BrokerHandler, Frame, FrameResponse, FrameType,
     HelloPayload, MessageHandler, NetworkConfig, PollPayload, PublishPayload,
@@ -20,6 +20,7 @@ fn test_broker() -> Arc<Broker> {
         default_qos: QoSLevel::AtLeastOnce,
         message_ttl: Duration::from_secs(5),
         per_subscriber_queue_capacity: 1024,
+        per_subscriber_backpressure: BackpressurePolicy::Drop,
         max_retries: 3,
         retry_base_delay: Duration::from_millis(20),
     }))
@@ -377,5 +378,3 @@ async fn invalid_publish_payload_is_rejected() {
 
     let _ = shutdown_tx.send(true);
 }
-
-


### PR DESCRIPTION
### Motivation
- Reduce contention on per-subscriber state by moving the hot-path queue off a `Mutex<VecDeque>` and into a bounded channel implementation.
- Reduce per-message locking by batching enqueues in the broker publish path.
- Make QoS1 inflight tracking cheaper on the hot-path by storing inflight state in a separate concurrent map.
- Expose configurable backpressure behavior (drop, block, shed) for full per-subscriber queues.

### Description
- Replaced `SubscriberQueue` internal `Mutex<VecDeque<...>>` with a bounded `tokio::mpsc` channel and added `enqueue_batch`/`send_entry` helpers to support batching and different backpressure policies via a new `BackpressurePolicy` enum and `BrokerConfig::per_subscriber_backpressure`.
- Moved QoS1 inflight tracking out of the queue into `SubscriberInflight` (a `Mutex<HashMap<DeliveryTag, QueueEntry>>`) and changed `dequeue`/`ack`/maintenance logic to use this separate inflight map.
- Implemented batching in `Broker::publish_with_wal_id` by collecting subscriber references and calling `enqueue_batch` to reduce per-message locking and cloning overhead.
- Added `QueueEntry::new` constructor and helper methods: `SubscriberQueue::requeue`, `SubscriberInflight::maintenance_tick`, `SubscriberInflight::insert/ack/len` and updated `maintenance_tick` to use the new inflight-based retry/requeue flow.
- Updated call sites and configs across the repo to provide the new backpressure setting (tests, bench, daemon): `bench/src/main.rs`, `blipmqd/src/main.rs`, `tests/daemon_integration.rs`, and `tests/chaos_recovery.rs`.

### Testing
- Ran `cargo fmt` to format modified files; formatting succeeded.
- No automated unit/integration tests (`cargo test`) were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981aa2fded4832c9f89786ef4bd77bb)